### PR TITLE
refactor: change `string` method name to `text`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const assertMaskIsString = (str) => {
   }
 };
 
-const string = (str, mask = '*') => {
+const text = (str, mask = '*') => {
   assertSubjectIsString(str);
   assertMaskIsString(mask);
 
@@ -40,7 +40,7 @@ const domain = (str, mask = '*') => {
   const tldIndex = str.lastIndexOf('.');
   if (tldIndex === -1) {
     // not a domain name
-    return string(str, mask);
+    return text(str, mask);
   }
 
   const start = str.slice(0, tldIndex);
@@ -48,10 +48,10 @@ const domain = (str, mask = '*') => {
 
   if (start.length === 0 || end.length === 0) {
     // not a domain name
-    return string(str, mask);
+    return text(str, mask);
   }
 
-  return `${string(start, mask)}.${end}`;
+  return `${text(start, mask)}.${end}`;
 };
 
 const email = (str, mask = '*') => {
@@ -61,17 +61,17 @@ const email = (str, mask = '*') => {
 
   if (parts.length !== 2) {
     // not an email address
-    return string(str, mask);
+    return text(str, mask);
   }
 
   const [start, end] = parts;
 
-  return `${string(start, mask)}@${domain(end, mask)}`;
+  return `${text(start, mask)}@${domain(end, mask)}`;
 };
 
 
 module.exports = {
-  string,
+  text,
   domain,
   email
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,13 +1,13 @@
-const { string, domain, email } = require('..');
+const { text, domain, email } = require('..');
 
 describe('Mask PII', () => {
-  test('string', () => {
-    expect(string('')).toEqual('********');
-    expect(string('a')).toEqual('a********');
-    expect(string('Hello world')).toEqual('H********d');
-    expect(string('Hello world', '★')).toEqual('H★★★★★★★★d');
-    expect(string('Hello world', '#')).toEqual('H########d');
-    expect(string('Hello world', '##')).toEqual('H################d');
+  test('text', () => {
+    expect(text('')).toEqual('********');
+    expect(text('a')).toEqual('a********');
+    expect(text('Hello world')).toEqual('H********d');
+    expect(text('Hello world', '★')).toEqual('H★★★★★★★★d');
+    expect(text('Hello world', '#')).toEqual('H########d');
+    expect(text('Hello world', '##')).toEqual('H################d');
 
     // test bad input
 
@@ -24,7 +24,7 @@ describe('Mask PII', () => {
 
     for (const input of notStrings) {
       expect(() => {
-        string(input);        // bad subject
+        text(input);         // bad subject
       }).toThrow(new TypeError('Subject is not a string'));
 
       expect(() => {
@@ -41,7 +41,7 @@ describe('Mask PII', () => {
       }
 
       expect(() => {
-        string('abc', input); // bad mask
+        text('abc', input); // bad mask
       }).toThrow(new TypeError('Mask is not a string'));
     }
   });


### PR DESCRIPTION
#### description
just a thought, but
I was just thinking perhaps `text` as a method name would be more 'human' / layman ! :)

since it'd now be `text, domain, email` 🤓 